### PR TITLE
feat: expose line-item cleared status (Fix #19)

### DIFF
--- a/packages/mcp/src/tools/line-items.ts
+++ b/packages/mcp/src/tools/line-items.ts
@@ -39,7 +39,7 @@ export function registerLineItemTools(
     "update_line_item",
     {
       title: "Update Line Item",
-      description: "Update a line item's account, amount, or memo",
+      description: "Update a line item's account, amount, memo, or cleared status",
       inputSchema: {
         line_item_id: z.number().describe("The line item ID to update"),
         account_id: z.number().optional().describe("New account ID"),
@@ -49,10 +49,11 @@ export function registerLineItemTools(
           .describe("New account name (alternative to account_id)"),
         amount: z.number().optional().describe("New amount"),
         memo: z.string().optional().describe("New memo"),
+        cleared: z.boolean().optional().describe("Set cleared/reconciled status"),
       },
       annotations: { readOnlyHint: false, destructiveHint: false },
     },
-    async ({ line_item_id, account_id, account_name, amount, memo }) => {
+    async ({ line_item_id, account_id, account_name, amount, memo, cleared }) => {
       let accountId = account_id;
       if (!accountId && account_name) {
         const resolved = resolveAccountIdOrError(client, undefined, account_name);
@@ -60,10 +61,11 @@ export function registerLineItemTools(
         accountId = resolved;
       }
 
-      const updates: { accountId?: number; amount?: number; memo?: string } = {};
+      const updates: { accountId?: number; amount?: number; memo?: string; cleared?: boolean } = {};
       if (accountId !== undefined) updates.accountId = accountId;
       if (amount !== undefined) updates.amount = amount;
       if (memo !== undefined) updates.memo = memo;
+      if (cleared !== undefined) updates.cleared = cleared;
 
       const affectedAccounts = client.lineItems.update(line_item_id, updates);
 

--- a/packages/sdk/src/repositories/line-items.ts
+++ b/packages/sdk/src/repositories/line-items.ts
@@ -19,7 +19,8 @@ export class LineItemRepository extends BaseRepository {
         a.ZPNAME as accountName,
         li.ZPTRANSACTIONAMOUNT as amount,
         li.ZPMEMO as memo,
-        li.ZPRUNNINGBALANCE as runningBalance
+        li.ZPRUNNINGBALANCE as runningBalance,
+        li.ZPCLEARED as cleared
       FROM ZLINEITEM li
       JOIN ZACCOUNT a ON li.ZPACCOUNT = a.Z_PK
       WHERE li.ZPTRANSACTION = ?
@@ -33,6 +34,7 @@ export class LineItemRepository extends BaseRepository {
       amount: number;
       memo: string | null;
       runningBalance: number | null;
+      cleared: number;
     }>;
 
     return rows.map((row) => ({
@@ -42,6 +44,7 @@ export class LineItemRepository extends BaseRepository {
       amount: row.amount,
       memo: row.memo,
       runningBalance: row.runningBalance,
+      cleared: row.cleared === 1,
     }));
   }
 
@@ -56,7 +59,8 @@ export class LineItemRepository extends BaseRepository {
         a.ZPNAME as accountName,
         li.ZPTRANSACTIONAMOUNT as amount,
         li.ZPMEMO as memo,
-        li.ZPRUNNINGBALANCE as runningBalance
+        li.ZPRUNNINGBALANCE as runningBalance,
+        li.ZPCLEARED as cleared
       FROM ZLINEITEM li
       JOIN ZACCOUNT a ON li.ZPACCOUNT = a.Z_PK
       WHERE li.Z_PK = ?
@@ -70,6 +74,7 @@ export class LineItemRepository extends BaseRepository {
           amount: number;
           memo: string | null;
           runningBalance: number | null;
+          cleared: number;
         }
       | undefined;
 
@@ -82,6 +87,7 @@ export class LineItemRepository extends BaseRepository {
       amount: row.amount,
       memo: row.memo,
       runningBalance: row.runningBalance,
+      cleared: row.cleared === 1,
     };
   }
 
@@ -156,9 +162,16 @@ export class LineItemRepository extends BaseRepository {
       accountId: "ZPACCOUNT",
       amount: "ZPTRANSACTIONAMOUNT",
       memo: "ZPMEMO",
+      cleared: "ZPCLEARED",
     };
 
-    const changes = this.executeUpdate("ZLINEITEM", lineItemId, updates, columnMap, {
+    const processedUpdates: Record<string, unknown> = { ...updates };
+
+    if (updates.cleared !== undefined) {
+      processedUpdates.cleared = updates.cleared ? 1 : 0;
+    }
+
+    const changes = this.executeUpdate("ZLINEITEM", lineItemId, processedUpdates, columnMap, {
       addModificationDate: false,
       incrementOpt: false,
     });

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -30,6 +30,7 @@ export interface LineItem {
   amount: number;
   memo: string | null;
   runningBalance: number | null;
+  cleared: boolean;
 }
 
 export interface CategorySpending {
@@ -120,6 +121,7 @@ export interface UpdateLineItemInput {
   accountId?: number;
   amount?: number;
   memo?: string;
+  cleared?: boolean;
 }
 
 export interface CreateAccountInput {

--- a/packages/sdk/tests/integration/line-items.test.ts
+++ b/packages/sdk/tests/integration/line-items.test.ts
@@ -243,4 +243,87 @@ describe("Line Item Integration Tests", () => {
       expect(accountIds).toContain(testData.accounts.groceries);
     });
   });
+
+  describe("line item cleared status", () => {
+    it("should expose cleared field on line items (defaults to false)", () => {
+      const { transactionId } = transactionRepo.create({
+        title: "Test Cleared",
+        date: "2024-01-15",
+        lineItems: [
+          { accountId: testData.accounts.checking, amount: -50.00 },
+        ],
+      });
+
+      const lineItems = lineItemRepo.getForTransaction(transactionId);
+
+      expect(lineItems).toHaveLength(1);
+      expect(lineItems[0]).toHaveProperty("cleared");
+      expect(lineItems[0].cleared).toBe(false);
+    });
+
+    it("should expose cleared field on get()", () => {
+      const { lineItemIds } = transactionRepo.create({
+        title: "Test Cleared Get",
+        date: "2024-01-15",
+        lineItems: [
+          { accountId: testData.accounts.checking, amount: -25.00 },
+        ],
+      });
+
+      const lineItem = lineItemRepo.get(lineItemIds[0]);
+
+      expect(lineItem).not.toBeNull();
+      expect(lineItem!.cleared).toBe(false);
+    });
+
+    it("should update cleared status via update()", () => {
+      const { lineItemIds } = transactionRepo.create({
+        title: "Test Cleared Update",
+        date: "2024-01-15",
+        lineItems: [
+          { accountId: testData.accounts.checking, amount: -30.00 },
+        ],
+      });
+
+      lineItemRepo.update(lineItemIds[0], { cleared: true });
+
+      const updated = lineItemRepo.get(lineItemIds[0]);
+      expect(updated!.cleared).toBe(true);
+    });
+
+    it("should clear individual line items independently", () => {
+      const { lineItemIds } = transactionRepo.create({
+        title: "Test Independent Cleared",
+        date: "2024-01-15",
+        lineItems: [
+          { accountId: testData.accounts.checking, amount: -100.00 },
+          { accountId: testData.accounts.savings, amount: 100.00 },
+        ],
+      });
+
+      lineItemRepo.update(lineItemIds[0], { cleared: true });
+
+      const first = lineItemRepo.get(lineItemIds[0]);
+      const second = lineItemRepo.get(lineItemIds[1]);
+
+      expect(first!.cleared).toBe(true);
+      expect(second!.cleared).toBe(false);
+    });
+
+    it("should unmark cleared status", () => {
+      const { lineItemIds } = transactionRepo.create({
+        title: "Test Unmark Cleared",
+        date: "2024-01-15",
+        lineItems: [
+          { accountId: testData.accounts.checking, amount: -40.00 },
+        ],
+      });
+
+      lineItemRepo.update(lineItemIds[0], { cleared: true });
+      expect(lineItemRepo.get(lineItemIds[0])!.cleared).toBe(true);
+
+      lineItemRepo.update(lineItemIds[0], { cleared: false });
+      expect(lineItemRepo.get(lineItemIds[0])!.cleared).toBe(false);
+    });
+  });
 });


### PR DESCRIPTION
Read and write ZPCLEARED on ZLINEITEM instead of only at the transaction level. Banktivity stores cleared/reconciled status per line item — each side of a transfer can be cleared independently.

- Add cleared field to LineItem type
- Read ZPCLEARED in getForTransaction() and get()
- Support updating cleared via update_line_item
- Add 5 integration tests for line-item cleared behavior

Generated by kiro-cli 1.0.242 (model: Auto) with human-in-the-loop review.