### PR TITLE
Fix #25: return native multi-currency line-item amounts

### DIFF
--- a/packages/sdk/src/repositories/line-items.ts
+++ b/packages/sdk/src/repositories/line-items.ts
@@ -17,7 +17,7 @@ export class LineItemRepository extends BaseRepository {
         li.Z_PK as id,
         li.ZPACCOUNT as accountId,
         a.ZPNAME as accountName,
-        li.ZPTRANSACTIONAMOUNT as amount,
+        li.ZPTRANSACTIONAMOUNT * li.ZPEXCHANGERATE as amount,
         li.ZPMEMO as memo,
         li.ZPRUNNINGBALANCE as runningBalance
       FROM ZLINEITEM li
@@ -54,7 +54,7 @@ export class LineItemRepository extends BaseRepository {
         li.Z_PK as id,
         li.ZPACCOUNT as accountId,
         a.ZPNAME as accountName,
-        li.ZPTRANSACTIONAMOUNT as amount,
+        li.ZPTRANSACTIONAMOUNT * li.ZPEXCHANGERATE as amount,
         li.ZPMEMO as memo,
         li.ZPRUNNINGBALANCE as runningBalance
       FROM ZLINEITEM li
@@ -220,7 +220,7 @@ export class LineItemRepository extends BaseRepository {
    */
   recalculateRunningBalances(accountId: number): void {
     const sql = `
-      SELECT li.Z_PK as id, li.ZPTRANSACTIONAMOUNT as amount, t.ZPDATE as date
+      SELECT li.Z_PK as id, li.ZPTRANSACTIONAMOUNT * li.ZPEXCHANGERATE as amount, t.ZPDATE as date
       FROM ZLINEITEM li
       JOIN ZTRANSACTION t ON li.ZPTRANSACTION = t.Z_PK
       WHERE li.ZPACCOUNT = ?

--- a/packages/sdk/tests/integration/line-items.test.ts
+++ b/packages/sdk/tests/integration/line-items.test.ts
@@ -3,6 +3,7 @@ import Database from "better-sqlite3";
 import { createTestDatabase, seedTestDatabase, createMockConnection, type TestData } from "./test-db.js";
 import { TransactionRepository } from "../../src/repositories/transactions.js";
 import { LineItemRepository } from "../../src/repositories/line-items.js";
+import { nowAsCoreData } from "../../src/utils/date.js";
 
 describe("Line Item Integration Tests", () => {
   let db: Database.Database;
@@ -68,6 +69,46 @@ describe("Line Item Integration Tests", () => {
     it("should return empty array for non-existent transaction", () => {
       const lineItems = lineItemRepo.getForTransaction(999);
       expect(lineItems).toEqual([]);
+    });
+  });
+
+  describe("multi-currency amount mapping", () => {
+    it("should return native amounts from get and getForTransaction", () => {
+      const usdCurrencyId = db.prepare(
+        `INSERT INTO ZCURRENCY (Z_ENT, Z_OPT, ZPCODE, ZPNAME) VALUES (4, 0, 'USD', 'US Dollar')`
+      ).run().lastInsertRowid as number;
+      const now = nowAsCoreData();
+      const usdAccountId = db.prepare(`
+        INSERT INTO ZACCOUNT (
+          Z_ENT, Z_OPT, ZCURRENCY, ZPACCOUNTCLASS,
+          ZPNAME, ZPFULLNAME, ZPCREATIONTIME, ZPMODIFICATIONDATE, ZPUNIQUEID
+        ) VALUES (3, 0, ?, 1006, 'USD Checking', 'USD Checking', ?, ?, 'usd-checking')
+      `).run(usdCurrencyId, now, now).lastInsertRowid as number;
+      const transactionId = db.prepare(`
+        INSERT INTO ZTRANSACTION (
+          Z_ENT, Z_OPT, ZPCURRENCY, ZPCREATIONTIME, ZPDATE,
+          ZPMODIFICATIONDATE, ZPTITLE, ZPUNIQUEID
+        ) VALUES (53, 0, ?, ?, ?, ?, 'Cross-currency transfer', 'cross-currency')
+      `).run(usdCurrencyId, now, now, now).lastInsertRowid as number;
+      const lineItemId = db.prepare(`
+        INSERT INTO ZLINEITEM (
+          Z_ENT, Z_OPT, ZPACCOUNT, ZPTRANSACTION, ZPCREATIONTIME,
+          ZPTRANSACTIONAMOUNT, ZPEXCHANGERATE, ZPRUNNINGBALANCE, ZPUNIQUEID
+        ) VALUES (19, 0, ?, ?, ?, 100, 0.8333333333, 83.33333333, 'cross-currency-line')
+      `).run(testData.accounts.checking, transactionId, now).lastInsertRowid as number;
+      db.prepare(`
+        INSERT INTO ZLINEITEM (
+          Z_ENT, Z_OPT, ZPACCOUNT, ZPTRANSACTION, ZPCREATIONTIME,
+          ZPTRANSACTIONAMOUNT, ZPEXCHANGERATE, ZPRUNNINGBALANCE, ZPUNIQUEID
+        ) VALUES (19, 0, ?, ?, ?, -100, 1, -100, 'cross-currency-offset')
+      `).run(usdAccountId, transactionId, now);
+
+      const lineItem = lineItemRepo.get(lineItemId);
+      const transactionLineItems = lineItemRepo.getForTransaction(transactionId);
+
+      expect(lineItem!.amount).toBeCloseTo(83.33333333, 6);
+      expect(transactionLineItems[0].amount).toBeCloseTo(83.33333333, 6);
+      expect(transactionLineItems[1].amount).toBe(-100);
     });
   });
 


### PR DESCRIPTION
# Linked issue
Fixes #25

# Summary
Return account-native line-item amounts by applying Banktivity's stored exchange rate when mapping individual line items and transaction line items. Running-balance recalculation uses the same native-currency calculation.

# Changes
- Map ZPTRANSACTIONAMOUNT * ZPEXCHANGERATE in LineItemRepository.get() and getForTransaction().
- Use the native amount in running-balance recalculation.
- Add an integration regression covering both retrieval paths and same-currency behavior.

# Verification
Targeted line-item integration suite: 14/14 passed.
Full Vitest suite: 15 files, 215 tests passed.
TypeScript build and git diff --check passed.
Configured MCP verification: fixture line item 8 returned 83.33333333333334 EUR from stored 100 * 0.8333333333; transaction retrieval returned the same native amount.

# Reviewer notes
No database migration or stored-data rewrite is required.

Generated by kiro-cli 2.16.2 (model: Auto) with human-in-the-loop review.