### PR TITLE
Fix #27: preserve exchange metadata on cross-currency creation

### DIFF
--- a/packages/sdk/src/repositories/line-items.ts
+++ b/packages/sdk/src/repositories/line-items.ts
@@ -114,7 +114,8 @@ export class LineItemRepository extends BaseRepository {
     transactionId: number,
     accountId: number,
     amount: number,
-    memo?: string
+    memo?: string,
+    exchangeRate = 1.0
   ): number {
     const now = nowAsCoreData();
     const uuid = generateUUID();
@@ -124,7 +125,7 @@ export class LineItemRepository extends BaseRepository {
         Z_ENT, Z_OPT, ZPACCOUNT, ZPTRANSACTION,
         ZPCREATIONTIME, ZPTRANSACTIONAMOUNT, ZPEXCHANGERATE,
         ZPRUNNINGBALANCE, ZPMEMO, ZPUNIQUEID, ZPCLEARED
-      ) VALUES (?, 0, ?, ?, ?, ?, 1.0, 0, ?, ?, 0)
+      ) VALUES (?, 0, ?, ?, ?, ?, ?, 0, ?, ?, 0)
     `;
 
     const result = this.db
@@ -135,6 +136,7 @@ export class LineItemRepository extends BaseRepository {
         transactionId,
         now,
         amount,
+        exchangeRate,
         memo ?? null,
         uuid
       );

--- a/packages/sdk/src/repositories/transactions.ts
+++ b/packages/sdk/src/repositories/transactions.ts
@@ -175,6 +175,19 @@ export class TransactionRepository extends BaseRepository {
       ? this.connection.getTransactionTypeId(input.transactionType)
       : null;
 
+    const accountCurrencyIds = input.lineItems.map((item) => {
+      const row = this.db
+        .prepare(`SELECT ZCURRENCY as currencyId FROM ZACCOUNT WHERE Z_PK = ?`)
+        .get(item.accountId) as { currencyId: number | null } | undefined;
+      return row?.currencyId ?? null;
+    });
+    const transactionCurrencyAmount =
+      currencyId === null
+        ? undefined
+        : input.lineItems.find(
+            (_, index) => accountCurrencyIds[index] === currencyId
+          )?.amount;
+
     const result = { transactionId: 0, lineItemIds: [] as number[] };
     const affectedAccounts = new Set<number>();
 
@@ -201,12 +214,29 @@ export class TransactionRepository extends BaseRepository {
 
       result.transactionId = txResult.lastInsertRowid as number;
 
-      for (const item of input.lineItems) {
+      for (const [index, item] of input.lineItems.entries()) {
+        const accountCurrencyId = accountCurrencyIds[index];
+        let transactionAmount = item.amount;
+        let exchangeRate = 1.0;
+
+        if (
+          transactionCurrencyAmount !== undefined &&
+          transactionCurrencyAmount !== 0 &&
+          accountCurrencyId !== null &&
+          accountCurrencyId !== currencyId &&
+          item.amount !== 0
+        ) {
+          transactionAmount =
+            Math.sign(item.amount) * Math.abs(transactionCurrencyAmount);
+          exchangeRate = Math.abs(item.amount / transactionAmount);
+        }
+
         const lineItemId = this.lineItems.create(
           result.transactionId,
           item.accountId,
-          item.amount,
-          item.memo
+          transactionAmount,
+          item.memo,
+          exchangeRate
         );
         result.lineItemIds.push(lineItemId);
         affectedAccounts.add(item.accountId);

--- a/packages/sdk/tests/integration/transactions.test.ts
+++ b/packages/sdk/tests/integration/transactions.test.ts
@@ -26,6 +26,64 @@ describe("Transaction Integration Tests", () => {
   });
 
   describe("create transaction with line items", () => {
+    it("should preserve exchange metadata for a cross-currency transfer", () => {
+      const usdCurrencyId = db.prepare(
+        `INSERT INTO ZCURRENCY (Z_ENT, Z_OPT, ZPCODE, ZPNAME) VALUES (4, 0, 'USD', 'US Dollar')`
+      ).run().lastInsertRowid as number;
+      const now = Date.now();
+      const usdAccountId = db.prepare(`
+        INSERT INTO ZACCOUNT (
+          Z_ENT, Z_OPT, ZCURRENCY, ZPACCOUNTCLASS,
+          ZPNAME, ZPFULLNAME, ZPCREATIONTIME, ZPMODIFICATIONDATE, ZPUNIQUEID
+        ) VALUES (3, 0, ?, 1006, 'USD Checking', 'USD Checking', ?, ?, 'usd-checking')
+      `).run(usdCurrencyId, now, now).lastInsertRowid as number;
+      const baseConnection = createMockConnection(db);
+      const connection = {
+        ...baseConnection,
+        getDefaultCurrencyId: () => usdCurrencyId,
+      };
+      lineItemRepo = new LineItemRepository(
+        db,
+        connection.entityTypes,
+        connection.tagJunctionColumn
+      );
+      transactionRepo = new TransactionRepository(connection as any, lineItemRepo);
+
+      const result = transactionRepo.create({
+        title: "Transfer USD to EUR",
+        date: "2024-01-15",
+        lineItems: [
+          { accountId: usdAccountId, amount: -200 },
+          { accountId: testData.accounts.checking, amount: 166.6666666667 },
+        ],
+      });
+
+      const transaction = db.prepare(
+        `SELECT ZPCURRENCY FROM ZTRANSACTION WHERE Z_PK = ?`
+      ).get(result.transactionId) as { ZPCURRENCY: number };
+      const lines = db.prepare(`
+        SELECT ZPACCOUNT, ZPTRANSACTIONAMOUNT, ZPEXCHANGERATE
+        FROM ZLINEITEM WHERE ZPTRANSACTION = ? ORDER BY Z_PK
+      `).all(result.transactionId) as Array<{
+        ZPACCOUNT: number;
+        ZPTRANSACTIONAMOUNT: number;
+        ZPEXCHANGERATE: number;
+      }>;
+
+      expect(transaction.ZPCURRENCY).toBe(usdCurrencyId);
+      expect(lines[0]).toMatchObject({
+        ZPACCOUNT: usdAccountId,
+        ZPTRANSACTIONAMOUNT: -200,
+        ZPEXCHANGERATE: 1,
+      });
+      expect(lines[1].ZPACCOUNT).toBe(testData.accounts.checking);
+      expect(lines[1].ZPTRANSACTIONAMOUNT).toBeCloseTo(200, 8);
+      expect(lines[1].ZPEXCHANGERATE).toBeCloseTo(0.8333333333, 8);
+      expect(
+        lines[1].ZPTRANSACTIONAMOUNT * lines[1].ZPEXCHANGERATE
+      ).toBeCloseTo(166.6666666667, 8);
+    });
+
     it("should create a transaction with multiple line items", () => {
       const result = transactionRepo.create({
         title: "Grocery Shopping",


### PR DESCRIPTION
## Linked issue
Fixes #27

## Summary
Treat create-transaction line-item amounts as account-native values. When a transaction contains accounts in different currencies, retain a common transaction amount and derive each foreign line's exchange rate so the stored product equals the caller's native amount.

## Changes
- Read each line item's account currency before insertion.
- Use the transaction-currency line amount as the common raw transaction amount.
- Store the derived foreign exchange rate in `ZPEXCHANGERATE`.
- Preserve rate `1.0` for same-currency transactions.
- Add an integration regression that inspects raw transaction and line-item columns.

## Verification
- Targeted transaction integration suite: 23/23 passed.
- Full Vitest suite: 15 files, 215 tests passed.
- TypeScript build and `git diff --check` passed.
- Configured MCP verification created a temporary USD/EUR transfer, returned native `-200 USD` and `166.6666666667 EUR`, and direct fixture inspection showed raw USD `-166.6666666667` at rate `1.19999999999976` and raw EUR `166.6666666667` at rate `1.0`. The temporary transaction was deleted and confirmed absent.

## Reviewer notes
The existing public per-line amount input is retained; for cross-currency transfers, callers provide each account's native amount.

Generated by kiro-cli 2.16.2 (model: Auto) with human-in-the-loop review.