### PR TITLE
Fix #28: derive transaction currency from account currencies

### DIFF
--- a/packages/sdk/src/repositories/transactions.ts
+++ b/packages/sdk/src/repositories/transactions.ts
@@ -170,7 +170,9 @@ export class TransactionRepository extends BaseRepository {
     const now = nowAsCoreData();
     const transactionDate = isoToCoreData(input.date);
     const transactionUUID = generateUUID();
-    const currencyId = this.connection.getDefaultCurrencyId();
+    const currencyId = this.getTransactionCurrencyId(
+      input.lineItems.map((item) => item.accountId)
+    );
     const transactionTypeId = input.transactionType
       ? this.connection.getTransactionTypeId(input.transactionType)
       : null;
@@ -218,6 +220,30 @@ export class TransactionRepository extends BaseRepository {
     }
 
     return result;
+  }
+
+  private getTransactionCurrencyId(accountIds: number[]): number | null {
+    const defaultCurrencyId = this.connection.getDefaultCurrencyId();
+    const uniqueAccountIds = [...new Set(accountIds)];
+
+    if (uniqueAccountIds.length === 0) return defaultCurrencyId;
+
+    const placeholders = uniqueAccountIds.map(() => "?").join(", ");
+    const rows = this.db
+      .prepare(
+        `SELECT ZCURRENCY as currencyId FROM ZACCOUNT WHERE Z_PK IN (${placeholders})`
+      )
+      .all(...uniqueAccountIds) as Array<{ currencyId: number | null }>;
+    const currencyIds = rows
+      .map((row) => row.currencyId)
+      .filter((currencyId): currencyId is number => currencyId !== null);
+
+    if (currencyIds.length !== uniqueAccountIds.length) return defaultCurrencyId;
+
+    const uniqueCurrencyIds = [...new Set(currencyIds)];
+    if (uniqueCurrencyIds.length === 1) return uniqueCurrencyIds[0];
+
+    return defaultCurrencyId;
   }
 
   /**

--- a/packages/sdk/tests/integration/transactions.test.ts
+++ b/packages/sdk/tests/integration/transactions.test.ts
@@ -4,6 +4,9 @@ import { createTestDatabase, seedTestDatabase, createMockConnection, type TestDa
 import { TransactionRepository } from "../../src/repositories/transactions.js";
 import { LineItemRepository } from "../../src/repositories/line-items.js";
 import { TagRepository } from "../../src/repositories/tags.js";
+import { Z_ENT, ACCOUNT_CLASS } from "../../src/constants.js";
+import { nowAsCoreData } from "../../src/utils/date.js";
+import { generateUUID } from "../../src/utils/uuid.js";
 
 describe("Transaction Integration Tests", () => {
   let db: Database.Database;
@@ -439,5 +442,58 @@ describe("Transaction Integration Tests", () => {
       const untagged = tagRepo.untagTransaction(transactionId, tagId);
       expect(untagged).toBe(2);
     });
+  });
+});
+
+
+describe("transaction currency", () => {
+  it("uses the shared non-default account currency", () => {
+    const testDb = createTestDatabase();
+    seedTestDatabase(testDb);
+    const connection = createMockConnection(testDb);
+    const testLineItemRepo = new LineItemRepository(testDb);
+    const testTransactionRepo = new TransactionRepository(connection as any, testLineItemRepo);
+
+    const currencyResult = testDb.prepare(`
+      INSERT INTO ZCURRENCY (Z_ENT, Z_OPT, ZPCODE, ZPNAME)
+      VALUES (4, 0, 'GEL', 'Georgian Lari')
+    `).run();
+    const gelCurrencyId = currencyResult.lastInsertRowid as number;
+    const now = nowAsCoreData();
+
+    const accountIds = ["GEL Checking", "GEL Savings"].map((name) => {
+      const result = testDb.prepare(`
+        INSERT INTO ZACCOUNT (
+          Z_ENT, Z_OPT, ZCURRENCY, ZPACCOUNTCLASS,
+          ZPNAME, ZPFULLNAME, ZPCREATIONTIME, ZPMODIFICATIONDATE, ZPUNIQUEID
+        ) VALUES (?, 0, ?, ?, ?, ?, ?, ?, ?)
+      `).run(
+        Z_ENT.ACCOUNT,
+        gelCurrencyId,
+        ACCOUNT_CLASS.CHECKING,
+        name,
+        name,
+        now,
+        now,
+        generateUUID()
+      );
+      return result.lastInsertRowid as number;
+    });
+
+    const { transactionId } = testTransactionRepo.create({
+      title: "GEL transfer",
+      date: "2024-01-15",
+      lineItems: accountIds.map((accountId, index) => ({
+        accountId,
+        amount: index === 0 ? 100 : -100,
+      })),
+    });
+
+    const row = testDb
+      .prepare("SELECT ZPCURRENCY as currencyId FROM ZTRANSACTION WHERE Z_PK = ?")
+      .get(transactionId) as { currencyId: number };
+
+    expect(row.currencyId).toBe(gelCurrencyId);
+    testDb.close();
   });
 });


### PR DESCRIPTION
## Linked issue
Fixes #28

## Summary
Derive the transaction-level currency from the currencies of its line-item accounts instead of always storing the database's first/default currency. Same-currency transactions between non-default-currency accounts now retain the correct Banktivity currency.

## Changes
- Read the currencies assigned to the transaction's line-item accounts before inserting `ZTRANSACTION`.
- Use the shared account currency for same-currency transactions, including non-default currencies such as GEL.
- Use the database default currency for mixed-currency transactions and when account currency information is unavailable.
- Add an integration regression covering a GEL-to-GEL transaction while EUR remains the first database currency.

## Verification
- Targeted transaction integration suite: 23/23 passed.
- Full Vitest suite: 15 files, 215 tests passed.
- SDK type check, SDK/MCP build, and `git diff --check` passed.

## Reviewer notes
This branch is based on `upstream/main` so the PR can be reviewed and accepted independently before being integrated into `local-integrated`.

Generated by kiro-cli 2.16.2 (model: gpt-5.6-luna) with human-in-the-loop review.