### PR TITLE
Fix/issue 29: Resolve Banktivity's configured home currency from StoreAttributes.plist

### DIFF
--- a/packages/sdk/src/connection.ts
+++ b/packages/sdk/src/connection.ts
@@ -1,6 +1,7 @@
 import Database from "better-sqlite3";
 import path from "path";
 import { readFileSync } from "node:fs";
+import { CurrencyMetadataError } from "./errors.js";
 
 /**
  * Database connection wrapper
@@ -30,33 +31,45 @@ export class DatabaseConnection {
   }
 
   /**
-   * Get the database's configured home currency ID
+   * Get the database's configured home currency ID.
+   *
+   * Currency metadata is authoritative and required. This method deliberately
+   * does not guess from ZCURRENCY row order when the bank package is invalid.
    */
-  getDefaultCurrencyId(): number | null {
-    let currencyCode: string | null = null;
+  getDefaultCurrencyId(): number {
+    const attributesPath = path.join(this.bankFilePath, "StoreAttributes.plist");
+    let attributes: string;
 
     try {
-      const attributesPath = path.join(this.bankFilePath, "StoreAttributes.plist");
-      const attributes = readFileSync(attributesPath, "utf8");
-      const match = attributes.match(
-        /<key>(?:homeCurrency|displayCurrencyCode)<\/key>\s*<string>([^<]+)<\/string>/
+      attributes = readFileSync(attributesPath, "utf8");
+    } catch (error) {
+      const reason = error instanceof Error ? `: ${error.message}` : "";
+      throw new CurrencyMetadataError(
+        `Unable to read StoreAttributes.plist at ${attributesPath}${reason}`
       );
-      currencyCode = match?.[1] ?? null;
-    } catch {
-      currencyCode = null;
     }
 
-    if (currencyCode) {
-      const sql = `SELECT Z_PK as id FROM ZCURRENCY WHERE ZPCODE = ?`;
-      const row = this.db.prepare(sql).get(currencyCode) as
-        | { id: number }
-        | undefined;
-      if (row?.id !== undefined) return row.id;
+    const match = attributes.match(
+      /<key>(?:homeCurrency|displayCurrencyCode)<\/key>\s*<string>([^<]+)<\/string>/
+    );
+    const currencyCode = match?.[1]?.trim();
+    if (!currencyCode) {
+      throw new CurrencyMetadataError(
+        "StoreAttributes.plist does not contain a supported home currency code"
+      );
     }
 
-    const sql = `SELECT Z_PK as id FROM ZCURRENCY LIMIT 1`;
-    const row = this.db.prepare(sql).get() as { id: number } | undefined;
-    return row?.id ?? null;
+    const sql = `SELECT Z_PK as id FROM ZCURRENCY WHERE ZPCODE = ?`;
+    const row = this.db.prepare(sql).get(currencyCode) as
+      | { id: number }
+      | undefined;
+    if (!row) {
+      throw new CurrencyMetadataError(
+        `Configured currency ${currencyCode} was not found in ZCURRENCY`
+      );
+    }
+
+    return row.id;
   }
 
   /**

--- a/packages/sdk/src/connection.ts
+++ b/packages/sdk/src/connection.ts
@@ -1,13 +1,16 @@
 import Database from "better-sqlite3";
 import path from "path";
+import { readFileSync } from "node:fs";
 
 /**
  * Database connection wrapper
  */
 export class DatabaseConnection {
   private db: Database.Database;
+  private bankFilePath: string;
 
   constructor(bankFilePath: string, readonly = false) {
+    this.bankFilePath = bankFilePath;
     const dbPath = path.join(bankFilePath, "StoreContent", "core.sql");
     this.db = new Database(dbPath, { readonly });
   }
@@ -27,9 +30,30 @@ export class DatabaseConnection {
   }
 
   /**
-   * Get the default currency ID (first currency in database)
+   * Get the database's configured home currency ID
    */
   getDefaultCurrencyId(): number | null {
+    let currencyCode: string | null = null;
+
+    try {
+      const attributesPath = path.join(this.bankFilePath, "StoreAttributes.plist");
+      const attributes = readFileSync(attributesPath, "utf8");
+      const match = attributes.match(
+        /<key>(?:homeCurrency|displayCurrencyCode)<\/key>\s*<string>([^<]+)<\/string>/
+      );
+      currencyCode = match?.[1] ?? null;
+    } catch {
+      currencyCode = null;
+    }
+
+    if (currencyCode) {
+      const sql = `SELECT Z_PK as id FROM ZCURRENCY WHERE ZPCODE = ?`;
+      const row = this.db.prepare(sql).get(currencyCode) as
+        | { id: number }
+        | undefined;
+      if (row?.id !== undefined) return row.id;
+    }
+
     const sql = `SELECT Z_PK as id FROM ZCURRENCY LIMIT 1`;
     const row = this.db.prepare(sql).get() as { id: number } | undefined;
     return row?.id ?? null;

--- a/packages/sdk/src/errors.ts
+++ b/packages/sdk/src/errors.ts
@@ -9,6 +9,16 @@ export class BanktivityError extends Error {
 }
 
 /**
+ * Error thrown when Banktivity currency metadata is unavailable or invalid
+ */
+export class CurrencyMetadataError extends BanktivityError {
+  constructor(message: string) {
+    super(message);
+    this.name = "CurrencyMetadataError";
+  }
+}
+
+/**
  * Error thrown when an entity is not found
  */
 export class NotFoundError extends BanktivityError {

--- a/packages/sdk/tests/connection.test.ts
+++ b/packages/sdk/tests/connection.test.ts
@@ -65,20 +65,13 @@ describe("DatabaseConnection", () => {
   });
 
   describe("getDefaultCurrencyId", () => {
-    it("should return currency id when found", () => {
+    it("should throw when StoreAttributes.plist is unavailable", () => {
       mockStatement.get.mockReturnValue({ id: 1 });
 
-      const result = connection.getDefaultCurrencyId();
-
-      expect(result).toBe(1);
-    });
-
-    it("should return null when no currency found", () => {
-      mockStatement.get.mockReturnValue(undefined);
-
-      const result = connection.getDefaultCurrencyId();
-
-      expect(result).toBeNull();
+      expect(() => connection.getDefaultCurrencyId()).toThrow(
+        "Unable to read StoreAttributes.plist"
+      );
+      expect(mockStatement.get).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/sdk/tests/default-currency.test.ts
+++ b/packages/sdk/tests/default-currency.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockStatement = {
+  get: vi.fn(),
+};
+const mockDbInstance = {
+  prepare: vi.fn().mockReturnValue(mockStatement),
+  close: vi.fn(),
+};
+
+vi.mock("better-sqlite3", () => {
+  return {
+    default: class MockDatabase {
+      constructor() {
+        return mockDbInstance;
+      }
+    },
+  };
+});
+
+vi.mock("node:fs", () => ({
+  readFileSync: vi.fn(() => `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>displayCurrencyCode</key>
+  <string>USD</string>
+</dict>
+</plist>`),
+}));
+
+import { DatabaseConnection } from "../src/connection.js";
+
+describe("DatabaseConnection default currency", () => {
+  beforeEach(() => {
+    mockStatement.get.mockReset();
+    mockStatement.get.mockImplementation((code?: string) => {
+      if (code === "USD") return { id: 5 };
+      return { id: 1 };
+    });
+  });
+
+  it("returns the currency configured in StoreAttributes.plist", () => {
+    const connection = new DatabaseConnection("/path/to/file.bank8");
+
+    expect(connection.getDefaultCurrencyId()).toBe(5);
+    expect(mockStatement.get).toHaveBeenCalledWith("USD");
+  });
+});

--- a/packages/sdk/tests/default-currency.test.ts
+++ b/packages/sdk/tests/default-currency.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
+const { mockReadFileSync } = vi.hoisted(() => ({
+  mockReadFileSync: vi.fn(),
+}));
 const mockStatement = {
   get: vi.fn(),
 };
@@ -19,24 +22,26 @@ vi.mock("better-sqlite3", () => {
 });
 
 vi.mock("node:fs", () => ({
-  readFileSync: vi.fn(() => `<?xml version="1.0" encoding="UTF-8"?>
+  readFileSync: mockReadFileSync,
+}));
+
+import { DatabaseConnection } from "../src/connection.js";
+
+const validPlist = `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
   <key>displayCurrencyCode</key>
   <string>USD</string>
 </dict>
-</plist>`),
-}));
-
-import { DatabaseConnection } from "../src/connection.js";
+</plist>`;
 
 describe("DatabaseConnection default currency", () => {
   beforeEach(() => {
-    mockStatement.get.mockReset();
-    mockStatement.get.mockImplementation((code?: string) => {
+    mockReadFileSync.mockReset().mockReturnValue(validPlist);
+    mockStatement.get.mockReset().mockImplementation((code?: string) => {
       if (code === "USD") return { id: 5 };
-      return { id: 1 };
+      return undefined;
     });
   });
 
@@ -45,5 +50,40 @@ describe("DatabaseConnection default currency", () => {
 
     expect(connection.getDefaultCurrencyId()).toBe(5);
     expect(mockStatement.get).toHaveBeenCalledWith("USD");
+  });
+
+  it("throws when StoreAttributes.plist cannot be read", () => {
+    mockReadFileSync.mockImplementation(() => {
+      throw new Error("ENOENT");
+    });
+    const connection = new DatabaseConnection("/path/to/file.bank8");
+
+    expect(() => connection.getDefaultCurrencyId()).toThrow(
+      "Unable to read StoreAttributes.plist"
+    );
+    expect(mockStatement.get).not.toHaveBeenCalled();
+  });
+
+  it("throws when StoreAttributes.plist has no supported currency key", () => {
+    mockReadFileSync.mockReturnValue(
+      "<?xml version=\"1.0\"?><plist><dict><key>creationDate</key><date>2026-01-01</date></dict></plist>"
+    );
+    const connection = new DatabaseConnection("/path/to/file.bank8");
+
+    expect(() => connection.getDefaultCurrencyId()).toThrow(
+      "does not contain a supported home currency"
+    );
+    expect(mockStatement.get).not.toHaveBeenCalled();
+  });
+
+  it("throws when the configured currency is absent from ZCURRENCY", () => {
+    mockStatement.get.mockReturnValue(undefined);
+    const connection = new DatabaseConnection("/path/to/file.bank8");
+
+    expect(() => connection.getDefaultCurrencyId()).toThrow(
+      "Configured currency USD was not found in ZCURRENCY"
+    );
+    expect(mockStatement.get).toHaveBeenCalledWith("USD");
+    expect(mockStatement.get).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/sdk/tests/integration/accounts.test.ts
+++ b/packages/sdk/tests/integration/accounts.test.ts
@@ -224,6 +224,35 @@ describe("Account Integration Tests", () => {
       const account = accountRepo.get(id);
       expect(account!.accountType).toBe("Expense");
     });
+
+    it("should fail before inserting when the default currency is unavailable", () => {
+      const initialCount = (
+        db.prepare("SELECT COUNT(*) as count FROM ZACCOUNT").get() as {
+          count: number;
+        }
+      ).count;
+      const failingConnection = {
+        ...createMockConnection(db),
+        getDefaultCurrencyId: () => {
+          throw new Error("default currency unavailable");
+        },
+      };
+      const failingRepo = new AccountRepository(failingConnection as any);
+
+      expect(() =>
+        failingRepo.create({
+          name: "Should Not Be Inserted",
+          accountClass: ACCOUNT_CLASS.CHECKING,
+        })
+      ).toThrow("default currency unavailable");
+
+      const finalCount = (
+        db.prepare("SELECT COUNT(*) as count FROM ZACCOUNT").get() as {
+          count: number;
+        }
+      ).count;
+      expect(finalCount).toBe(initialCount);
+    });
   });
 
   describe("category analysis", () => {


### PR DESCRIPTION
## Linked issue
Fixes #29

## Summary
Resolve Banktivity's configured home currency from `StoreAttributes.plist` and fail loudly when the metadata cannot be read, parsed, or matched to `ZCURRENCY`. The implementation no longer guesses from the first currency row or returns `null` at the default-currency boundary.

## Changes
- Read `homeCurrency` or the observed Banktivity `displayCurrencyCode` from the root-level `StoreAttributes.plist`.
- Resolve the configured code to its `ZCURRENCY` primary key.
- Throw `CurrencyMetadataError` for missing/unreadable, malformed/incomplete, or unknown currency metadata.
- Remove the arbitrary `SELECT Z_PK FROM ZCURRENCY LIMIT 1` fallback.
- Make account creation and mixed-currency transaction creation fail before database writes when required home currency metadata is invalid or unavailable.
- Preserve same-currency transaction creation when all account currencies are known.
- Add regression coverage for valid, missing, malformed/incomplete, and unknown plist metadata plus write-path no-insert guarantees.
- Add valid currency metadata to the MCP Core Data lifecycle test fixture.

## Verification

### `fix/issue-29`

- Targeted default-currency and connection suites: 13/13 passed.
- Targeted account integration suite: 28/28 passed.
- Full Vitest suite: 16 files, 218 tests passed.
- SDK type check and SDK/MCP build passed.
- `git diff --check` passed.
- Commit: `47a7bfa` (`Fix #29: fail fast on invalid currency metadata`).

### `local-integrated`

- Targeted default-currency and connection suites: 14/14 passed.
- Targeted account integration suite: 29/29 passed.
- Targeted transaction integration suite: 24/24 passed.
- Targeted MCP Core Data lifecycle suite: 6/6 passed.
- Full Vitest suite: 20 files, 273 tests passed.
- SDK/MCP build passed.
- `git diff --check upstream/main..HEAD` passed.
- No tracked merge-conflict markers remain.
- Integration commits: `91bf712` and `c07af6e`.